### PR TITLE
Add a placeholder for websocket URL

### DIFF
--- a/stanzaio/index.html
+++ b/stanzaio/index.html
@@ -9,7 +9,7 @@
       <form id="loginInfo">
         <label>JID: <input id="jid" type="text" name="jid" value="me@example.com"/></label>
         <label>Password: <input id="password" type="password" name="password" /></label>
-        <label>WebSocket URL: <input id="wsURL" type="text" name="wsURL" value="" /></label>
+        <label>WebSocket URL: <input id="wsURL" type="text" name="wsURL" value="" placeholder="ws://localhost:5280/xmpp-websocket/" /></label>
         <input id="connect" type="submit" value="Connect" />
       </form>
       <h2>Start Video Session</h2>


### PR DESCRIPTION
If you are forgetful (like me) you constantly forget the path part and spend time wondering why your connection isn't working. This provides a hint (for prosody at least).
