### PR TITLE
add library name to the page title to easy the navigation

### DIFF
--- a/jslix-jingle/index.html
+++ b/jslix-jingle/index.html
@@ -1,6 +1,7 @@
 <html>
   <head>
-    <title>Jingle Interop Testing</title>
+    <meta charset="UTF-8">
+    <title>jslix.jingle — Jingle Interop Testing</title>
     <script src="https://rawgithub.com/jrburke/requirejs/2.1.9/require.js"></script>
     <script src="require-config.js"></script>
     <style type='text/css'>

--- a/stanzaio/index.html
+++ b/stanzaio/index.html
@@ -1,6 +1,7 @@
 <html>
   <head>
-    <title>Jingle Interop Testing</title>
+    <meta charset="UTF-8">
+    <title>stanza.io — Jingle Interop Testing</title>
     <script src="attachmediastream.bundle.js"></script>
     <script src="stanzaio.bundle.js"></script>
   </head>

--- a/strophejingle/index.html
+++ b/strophejingle/index.html
@@ -1,6 +1,7 @@
 <html>
   <head>
-    <title>Jingle Interop Testing</title>
+    <meta charset="UTF-8">
+    <title>strophe.jingle — Jingle Interop Testing</title>
     <script src="//ajax.googleapis.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
     <script src="strophejingle.bundle.js"></script>
     <style type='text/css'>

--- a/xmpp-ftw/index.html
+++ b/xmpp-ftw/index.html
@@ -1,6 +1,7 @@
 <html>
   <head>
-    <title>Jingle Interop Testing</title>
+    <title>xmpp-ftw — Jingle Interop Testing</title>
+    <meta charset="UTF-8">
   </head>
   <body>
     <div id="settings">


### PR DESCRIPTION
I've added a library name to the title of the testing pages to distinct them in the tab bar easier. If you find this useful, merge the request. :)
