### PR TITLE
Failed to execute 'addStream' on 'RTCPeerConnection'

### DIFF
--- a/stanzaio/index.html
+++ b/stanzaio/index.html
@@ -61,7 +61,7 @@
       var loginInfo = document.getElementById('loginInfo');
 
       var inlog = console.log.bind(console, '<<in');
-      var outlog = console.log.bind(console, 'out>>');;
+      var outlog = console.log.bind(console, 'out>>');
 
       loginInfo.onsubmit = function (e) {
         if (e.preventDefault) e.preventDefault();
@@ -138,7 +138,7 @@
           e.preventDefault();
           var jid = document.getElementById('peer').value;
           var session = client.jingle.createMediaSession(jid);
-          session.addStream(localMedia.localStream);
+          session.addStream(localMedia.localStreams[0]);
           session.start();
           return false;
         };


### PR DESCRIPTION
Uncaught DOMException: Failed to execute 'addStream' on 'RTCPeerConnection': The 1st argument provided is either null, or an invalid MediaStream object.
    at RTCPeerConnection.addStream (/stanzaio.bundle.js:31328:23)
    at MediaSession.addStream (/stanzaio.bundle.js:9551:17)
    at HTMLFormElement.callInfo.onsubmit (http://localhost:8000/:135:19)
RTCPeerConnection.addStream @ stanzaio.bundle.js:31328
addStream @ stanzaio.bundle.js:9551
callInfo.onsubmit @ (index):135